### PR TITLE
Fasagidag/deleting oldest cid

### DIFF
--- a/include/rddlSDKAbst.h
+++ b/include/rddlSDKAbst.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #define EXT_PUB_KEY_SIZE 112 
 
-#define MAX_CID_FILE_SIZE (24*45)   // One every hour, 45 days in total
+#define MAX_CID_FILE_SIZE (24*40)   // One every hour, 40 days in total
 
 /* MAKE IT GENERIC */
 /* Cozemedim */

--- a/include/rddlSDKAbst.h
+++ b/include/rddlSDKAbst.h
@@ -3,7 +3,7 @@
 #include "stdbool.h"
 #include "stddef.h"
 
-
+ 
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -13,14 +13,22 @@ extern "C" {
 #define ADDRESS_HASH_SIZE 20
 #define ADDRESS_TAIL 20
 
-#define EXT_PUB_KEY_SIZE 112
+#define EXT_PUB_KEY_SIZE 112 
+
+#define MAX_CID_FILE_SIZE (24*45)   // One every hour, 45 days in total
 
 /* MAKE IT GENERIC */
 /* Cozemedim */
 #define PSTR(s)   (s)
 
+#ifdef LINUX_MACHINE
+    #define CID_FILE_DIRECTORY "./"
+#else
+    #define CID_FILE_DIRECTORY "/"
+#endif
 
-/* MAKE IT GENERIC */
+
+/* MAKE IT GENERIC */ 
 extern uint8_t sdk_priv_key_planetmint[32+1];
 extern uint8_t sdk_priv_key_liquid[32+1];
 extern uint8_t sdk_pub_key_planetmint[33+1];
@@ -40,6 +48,8 @@ extern char sdk_denom[20];
 
 extern bool sdk_readSeed;
 extern char responseArr[4096];
+
+extern uint32_t num_of_cid_files;
 
 typedef struct PoPInfo {
     int64_t blockHeight;
@@ -66,6 +76,10 @@ bool setSetting(uint32_t index, const char* replacementText);
 
 uint8_t* abstGetStack( size_t size );
 void abstClearStack();
+int abstGetNumOfCIDFiles(const char* path);
+int abstDeleteOldestCIDFile(const char* path);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rddlSDKAbst.h
+++ b/include/rddlSDKAbst.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #define EXT_PUB_KEY_SIZE 112 
 
-#define MAX_CID_FILE_SIZE (24*40)   // One every hour, 40 days in total
+#define MAX_CID_FILE_SIZE (24*42)   // One every hour, 42 days in total
 
 /* MAKE IT GENERIC */
 /* Cozemedim */

--- a/include/rddlSDKAbst.h
+++ b/include/rddlSDKAbst.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "stdbool.h"
-#include "stddef.h"
+#include "stddef.h" 
 
  
 #ifdef __cplusplus
-extern "C" {
+extern "C" { 
 #endif
 
 

--- a/include/rddlSDKUtils.h
+++ b/include/rddlSDKUtils.h
@@ -15,6 +15,7 @@ int copyJsonValueString(char *buffer, size_t buffer_len, const char *json, const
 int parseJsonBoolean(const char *json, const char *key, bool *result);
 bool getPoPInfoFromJSON( const char* json);
 bool convertStringToInt64( const char* valueString, int64_t* targetValue );
+void checkNumOfCIDFiles(const char* path);
 
 #ifdef __cplusplus
 }

--- a/runTest.sh
+++ b/runTest.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 cd build
-./test/testRddlSDK && ./test/testSDKUtils 
+# ./test/testRddlSDK && ./test/testSDKUtils 
+./test/testSDKUtils 
 cd ..

--- a/runTest.sh
+++ b/runTest.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 cd build
-# ./test/testRddlSDK && ./test/testSDKUtils 
-./test/testSDKUtils 
+./test/testRddlSDK && ./test/testSDKUtils 
 cd ..

--- a/src/platform/linux/rddlSDKAbst.c
+++ b/src/platform/linux/rddlSDKAbst.c
@@ -198,9 +198,11 @@ char* getGPSstring(){
 }
 
 uint8_t* abstGetStack( size_t size ){
-  return (uint8_t*) malloc( size );
+  return getStack( size );
 }
-void abstClearStack() {}
+void abstClearStack() {
+  clearStack();
+}
 
 bool getAccountInfo( uint64_t* account_id, uint64_t* sequence )
 {

--- a/src/platform/linux/rddlSDKAbst.c
+++ b/src/platform/linux/rddlSDKAbst.c
@@ -418,7 +418,6 @@ int abstDeleteOldestCIDFile(const char* path){
             return 0;
         }
     } else {
-        printf("No file found with a name longer than 20 characters.\n");
         return -1;
     }
   } else {

--- a/src/platform/tasmota/rddlSDKAbst.c
+++ b/src/platform/tasmota/rddlSDKAbst.c
@@ -54,6 +54,8 @@ static char curlOutput[1024];
 
 char responseArr[4096];
 
+uint32_t num_of_cid_files = 0;
+
 
 PoPInfo popParticipation;
 void resetPopInfo(){  memset( &popParticipation, 0, sizeof(PoPInfo)); }
@@ -143,6 +145,26 @@ bool setSetting(uint32_t index, const char* replacementText){
 uint8_t* abstGetStack( size_t size ){
   return getStack( size );
 }
+
+
 void abstClearStack() {
   clearStack();
+}
+
+
+int abstGetNumOfCIDFiles(const char* path){
+  return tasmotaGetNumOfCIDFiles(path);
+}
+
+
+int abstDeleteOldestCIDFile(const char* path){
+  if(tasmotaDeleteOldestCIDFiles() != -1)
+    return 0;
+
+  if(num_of_cid_files >= MAX_CID_FILE_SIZE){
+    tasmotaGetCIDFiles(path);
+    tasmotaSortCIDFiles();
+  }
+
+  return -1;
 }

--- a/src/platform/tasmota/rddlSDKAbst.c
+++ b/src/platform/tasmota/rddlSDKAbst.c
@@ -164,7 +164,11 @@ int abstDeleteOldestCIDFile(const char* path){
   if(num_of_cid_files >= MAX_CID_FILE_SIZE){
     tasmotaGetCIDFiles(path);
     tasmotaSortCIDFiles();
+    if(tasmotaDeleteOldestCIDFiles() != -1)
+      return 0;
   }
+
+  
 
   return -1;
 }

--- a/src/platform/tasmota/tasmotaUtils.cpp
+++ b/src/platform/tasmota/tasmotaUtils.cpp
@@ -227,7 +227,7 @@ void tasmotaGetCIDFiles(const char *path){
     return;
   }
 
-  File dir = filesystem->open("/");
+  File dir = filesystem->open(path);
   String nextFile = dir.getNextFileName();
 
   int cnt=0;

--- a/src/platform/tasmota/tasmotaUtils.h
+++ b/src/platform/tasmota/tasmotaUtils.h
@@ -17,8 +17,10 @@ void vAddLogLineTasmota(const char* msg, va_list args);
 int tasmotaSerialPrint(const char* msg);
 char* tasmotaGetSetting(uint32_t index);
 bool tasmotaSetSetting(uint32_t index, const char* replacementText);
-
-
+int tasmotaGetNumOfCIDFiles(const char *path);
+void tasmotaGetCIDFiles(const char *path);
+void tasmotaSortCIDFiles();
+void tasmotaDeleteOldestCIDFiles();
 
 #ifdef __cplusplus
 }

--- a/src/platform/tasmota/tasmotaUtils.h
+++ b/src/platform/tasmota/tasmotaUtils.h
@@ -20,7 +20,7 @@ bool tasmotaSetSetting(uint32_t index, const char* replacementText);
 int tasmotaGetNumOfCIDFiles(const char *path);
 void tasmotaGetCIDFiles(const char *path);
 void tasmotaSortCIDFiles();
-void tasmotaDeleteOldestCIDFiles();
+int tasmotaDeleteOldestCIDFiles();
 
 #ifdef __cplusplus
 }

--- a/src/rddlSDKAPI.c
+++ b/src/rddlSDKAPI.c
@@ -6,6 +6,7 @@
 #include <stdint.h> 
 #include <errno.h>
 #include <fcntl.h>
+#include <time.h>
 
 #include "rddl.h"
 #include "rddl_cid.h"
@@ -144,11 +145,6 @@ void runRDDLSDKNotarizationWorkflow(const char* data_str, size_t data_length){
 
   generateAnyCIDAttestMsg(&anyMsg, cid_str, sdk_priv_key_planetmint, sdk_pub_key_planetmint, sdk_address, sdk_ext_pub_key_planetmint );
   sendMessages( &anyMsg );
-
-#ifdef LINUX_MACHINE
-  free(cid_str);
-  free(local_data);
-#endif
 }
 
 bool getPoPFromChain(const char* blockHeight ){

--- a/src/rddlSDKAPI.c
+++ b/src/rddlSDKAPI.c
@@ -126,8 +126,14 @@ void runRDDLSDKNotarizationWorkflow(const char* data_str, size_t data_length){
   //compute CID
   char* cid_str = create_cid_v1_from_string( (const char*) local_data );
 
+  // Add timestamp to the end of cid
+  char cid_name[100] = {0};
+  long curr_time;
+  time(&curr_time);
+  sprintf(cid_name, "%s%ld",cid_str, curr_time);
+
   // store cid
-  rddl_writefile( cid_str, (uint8_t*)local_data, data_size );
+  rddl_writefile( cid_name, (uint8_t*)local_data, data_size );
   checkNumOfCIDFiles(CID_FILE_DIRECTORY);
 
   // register CID

--- a/src/rddlSDKAPI.c
+++ b/src/rddlSDKAPI.c
@@ -128,6 +128,7 @@ void runRDDLSDKNotarizationWorkflow(const char* data_str, size_t data_length){
 
   // store cid
   rddl_writefile( cid_str, (uint8_t*)local_data, data_size );
+  checkNumOfCIDFiles(CID_FILE_DIRECTORY);
 
   // register CID
   //registerCID( cid_str );

--- a/src/rddlSDKUtils.c
+++ b/src/rddlSDKUtils.c
@@ -442,3 +442,14 @@ bool getPoPInfoFromJSON( const char* json){
   
   return true;
 }
+
+
+void checkNumOfCIDFiles(const char* path){
+  if(num_of_cid_files == 0)
+    num_of_cid_files = abstGetNumOfCIDFiles(path);
+  else
+    num_of_cid_files++;
+  
+  if(abstDeleteOldestCIDFile(path) == 0)
+    num_of_cid_files--;
+}

--- a/src/rddlSDKUtils.c
+++ b/src/rddlSDKUtils.c
@@ -297,10 +297,6 @@ int registerMachine(void* anyMsg, const char* machineCategory, const char* manuf
   machineMsg.machine = &machine;
   int ret = generateAnyAttestMachineMsg((Google__Protobuf__Any*)anyMsg, &machineMsg);
 
-#ifdef LINUX_MACHINE
-  free(deviceDescription);
-#endif
-
   if( ret<0 )
   {
     sprintf(responseArr, "No Attestation message\n");
@@ -321,10 +317,6 @@ int sendMessages( void* pAnyMsg) {
   sprintf(responseArr, "TX broadcast:\n");
   AddLogLineAbst(responseArr);
   int broadcast_return = broadcast_transaction( tx_payload );
-
-#ifdef LINUX_MACHINE
-  free(tx_payload);
-#endif
 
   return broadcast_return;
 }

--- a/test/testSDKUtils.c
+++ b/test/testSDKUtils.c
@@ -90,8 +90,14 @@ void generateTestCIDFiles(int count){
     char* cid_str = create_cid_v1_from_string(rand_string(rand_str, 15));
     char path[128] = "CID_FILES/";
     strcat(path, cid_str);
-    rddl_writefile( path, (uint8_t*)"TEST_DATA", sizeof("TEST_DATA") );
+
+    char cid_name[256] = {0};
+    long curr_time;
+    time(&curr_time);
+    sprintf(cid_name, "%s%ld",path, curr_time);
+    rddl_writefile( cid_name, (uint8_t*)"TEST_DATA", sizeof("TEST_DATA") );
     checkNumOfCIDFiles("./CID_FILES/");
+    usleep(10000);
   }
 }
 

--- a/test/testSDKUtils.c
+++ b/test/testSDKUtils.c
@@ -84,13 +84,12 @@ void generateTestCIDFiles(int count){
   srand(time(NULL));
 
   for(int i=0; i<count; ++i){
+    abstClearStack();
     char* cid_str = create_cid_v1_from_string(rand_string(rand_str, 15));
     char path[128] = "CID_FILES/";
     strcat(path, cid_str);
     rddl_writefile( path, (uint8_t*)"TEST_DATA", sizeof("TEST_DATA") );
     checkNumOfCIDFiles("./CID_FILES/");
-    free(cid_str);
-    usleep(200000);
   }
 }
 
@@ -109,8 +108,8 @@ int main()
 {
     UNITY_BEGIN();
 
-    RUN_TEST(testCopyJsonValueString);
-    RUN_TEST(testGetPoPInfoFromJson);
+    // RUN_TEST(testCopyJsonValueString);
+    // RUN_TEST(testGetPoPInfoFromJson);
     RUN_TEST(tesCheckNumOfCIDFiles);
 
     return UNITY_END();

--- a/test/testSDKUtils.c
+++ b/test/testSDKUtils.c
@@ -108,8 +108,8 @@ int main()
 {
     UNITY_BEGIN();
 
-    // RUN_TEST(testCopyJsonValueString);
-    // RUN_TEST(testGetPoPInfoFromJson);
+    RUN_TEST(testCopyJsonValueString);
+    RUN_TEST(testGetPoPInfoFromJson);
     RUN_TEST(tesCheckNumOfCIDFiles);
 
     return UNITY_END();

--- a/test/testSDKUtils.c
+++ b/test/testSDKUtils.c
@@ -2,10 +2,14 @@
 #include "stdio.h"
 #include "stdint.h"
 #include <stdbool.h> 
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#include <unistd.h>
 #include "rddlSDKUtils.h"
 #include "rddlSDKAbst.h"
 #include "unity.h"
+#include "rddl_cid.h"
 
 const char testPoPInfo[]="{\
   \"challenge\": {\
@@ -58,12 +62,56 @@ void testGetPoPInfoFromJson(void){
   TEST_ASSERT_TRUE( !popParticipation.finished );
 }
 
+
+char *rand_string(char *str, size_t size)
+{
+  const char charset[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  if (size) {
+      --size;
+      for (size_t n = 0; n < size; n++) {
+          int key = rand() % (int) (sizeof charset - 1);
+          str[n] = charset[key];
+      }
+      str[size] = '\0';
+  }
+  return str;
+}
+
+
+void generateTestCIDFiles(int count){
+  char rand_str[20];
+  srand(time(NULL));
+
+  for(int i=0; i<count; ++i){
+    char* cid_str = create_cid_v1_from_string(rand_string(rand_str, 15));
+    char path[128] = "CID_FILES/";
+    strcat(path, cid_str);
+    rddl_writefile( path, (uint8_t*)"TEST_DATA", sizeof("TEST_DATA") );
+    checkNumOfCIDFiles("./CID_FILES/");
+    free(cid_str);
+    usleep(200000);
+  }
+}
+
+
+void tesCheckNumOfCIDFiles(){
+  int test_cnt = 2080;
+
+  generateTestCIDFiles(test_cnt);
+
+  int file_num_e = abstGetNumOfCIDFiles("./CID_FILES/");
+  TEST_ASSERT_EQUAL_INT( file_num_e, MAX_CID_FILE_SIZE - 1 );
+}
+
+
 int main()
 {
     UNITY_BEGIN();
 
     RUN_TEST(testCopyJsonValueString);
     RUN_TEST(testGetPoPInfoFromJson);
+    RUN_TEST(tesCheckNumOfCIDFiles);
 
     return UNITY_END();
 }


### PR DESCRIPTION
- Added algorithm that deletes the oldest CID file. To make the algorithm run faster in Tasmota, the creation time of the CID was added to the end of the name. This reduced the time from 5 minutes (when the file creation time is retrieved from the file system) to 1 second.
- Malloc was also removed in Linux compilation, so free functions were also removed.
- Bugs fixed on getSetting and setSetting function for linux
- Algorithm tested on both Linux and Tasmota